### PR TITLE
Use browserHistory for routes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Navbar } from 'react-bootstrap';
-import { FormGroup } from 'react-bootstrap';
-import { FormControl } from 'react-bootstrap';
-import { Button } from 'react-bootstrap';
-let ReactRouter = require('react-router');
-let Router = ReactRouter.Router;
-let Route = ReactRouter.Route;
+import { Navbar, FormGroup, FormControl, Button } from 'react-bootstrap';
+import { Router, Route, browserHistory, Link } from 'react-router';
 require('../css/custom.css');
-import { hashHistory } from 'react-router';
 
 class JobIndex extends React.Component {
   constructor() {
@@ -83,7 +77,7 @@ class Header extends React.Component {
         <Navbar>
           <Navbar.Header>
             <Navbar.Brand>
-              <a href="#">Looking For</a>
+              <Link to="/">Looking For</Link>
             </Navbar.Brand>
             <JobSeachBar />
             <Navbar.Toggle />
@@ -157,8 +151,8 @@ const Job = ({job, fullListing}) => {
             })}
           </ul>
         </div>
-        {fullListing ? "" : <button><a href="/#/job/1">View Details</a></button>}
-        {fullListing ? <a href="/">Back to all jobs</a> : ""}
+        {fullListing ? "" : <button><Link to="/job/1">View Details</Link></button>}
+        {fullListing ? <Link to="/">Back to all jobs</Link> : ""}
       </div>
     )
   } else {
@@ -181,7 +175,7 @@ const NotFound = ({}) => {
 }
 
 let routes = (
-  <Router history={hashHistory}>
+  <Router history={browserHistory}>
     <Route path="/" component={JobIndex}/>
     <Route path="/job/:jobId" component={JobShow}/>
     <Route path="*" component={NotFound}/>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Front end for Lookingfor app",
   "main": "server.js",
   "scripts": {
-    "dev": "webpack-dev-server --content-base public/ --progress --colors",
+    "dev": "webpack-dev-server --content-base public/ --progress --colors --history-api-fallback",
     "start": "nodemon server.js"
   },
   "repository": {

--- a/public/index.html
+++ b/public/index.html
@@ -12,5 +12,5 @@
   <body>
     <div id="application"></div>
   </body>
-  <script src="main.bundle.js"></script>
+  <script src="/main.bundle.js"></script>
 </html>


### PR DESCRIPTION
This PR cleans up the routes by using `browserHistory` and adding a line to `package.json`.

Docs for how to do this are located here: https://github.com/reactjs/react-router-tutorial/tree/master/lessons/10-clean-urls

This also changes the `<a>` tags to Links because Links know which router they originate from and thus you can click back and forth with them: https://github.com/reactjs/react-router-tutorial/tree/master/lessons/03-navigating-with-link

If you visit the site at `http://localhost:8080/` you will be able to click around and see the routes in action. Unfortunately, it doesn't work in `http://localhost:8080/webpack-dev-server/`. The links work, but the url's don't change. It must have something to do with webpack, but I don't know how to fix this.

I'm only merging into the previous `20-browser-history` branch so you can easily see what's been changed.

@rrgayhart @cheljoh @natevenn @brianrip 

closes #20 