### PR TITLE
Remove trimmed job description from job show page

### DIFF
--- a/lib/components/job.js
+++ b/lib/components/job.js
@@ -8,8 +8,8 @@ class Job extends React.Component {
   }
 
   createMarkup() {
-    return {__html: this.props.fullListing ? this.props.job.description : helpers.trimBody(this.props.job.description, 100)}
-    };
+    return {__html: this.props.fullListing ? this.props.job.description : "" };
+    }
 
   render() {
     if (typeof this.props.job.title !== "undefined"){

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,11 +1,5 @@
 let helpers = {
 
-  trimBody(bodyText, maxLength) {
-    let bodyLength = bodyText.lastIndexOf(' ', maxLength);
-    let truncatedBody = bodyText.length > maxLength ? bodyText.substring(0, bodyLength) + '...' : bodyText
-    return truncatedBody
-  },
-
   notFound({}) {
     return <h1>Not Found!</h1>
   },


### PR DESCRIPTION
The trim body method causes errors if it splits tags. Took this out of the job show page.

closes #26 