### PR TITLE
implement axios call on missed ajax call in TrendsIndex

### DIFF
--- a/lib/components/TrendsIndex.js
+++ b/lib/components/TrendsIndex.js
@@ -13,10 +13,10 @@ class TrendsIndex extends React.Component {
   }
 
   getJobTechCountData() {
-    $.getJSON(`https://lookingforme.herokuapp.com/api/v1/current_openings_technology_count`,
-      (response) => {
-        this.setState({ data: response.trends });
-      });
+    axios.get(`https://lookingforme.herokuapp.com/api/v1/current_openings_technology_count`)
+      .then(response => response.data)
+      .then(response => this.setState({ data: response.trends }))
+      .catch(error => console.log(error));
   }
 
   render() {


### PR DESCRIPTION
Brian must have missed the API call in TrendsIndex. 

this commit is evidence about how much faster the app is with axios instead of jquery/ajax. after converting the call to use axios, the trends page loads split-second fast.

I find it interesting, though, that this component was not importing jquery before, but it still worked, and is not importing axios now, and still has no issues.
