### PR TITLE
fix bind typo to call in JobShow

### DIFF
--- a/lib/components/JobShow.js
+++ b/lib/components/JobShow.js
@@ -12,7 +12,7 @@ class JobShow extends React.Component {
   }
 
   componentDidMount() {
-    LookingForService.getSingleJob.bind(this)
+    LookingForService.getSingleJob.call(this)
   }
 
   render() {


### PR DESCRIPTION
this PR fixes using `bind` instead of `call` in the JobShow component. 