### PR TITLE
 fix see all jobs button

### DIFF
--- a/lib/components/JobIndex.js
+++ b/lib/components/JobIndex.js
@@ -40,7 +40,7 @@ class JobIndex extends React.Component {
       <div>
         <Header />
         <div className="container">
-          <SearchBar getFilteredJobs={this.getFilteredJobs.bind(this)} />
+        <SearchBar getAllRecentJobs={this.componentDidMount.bind(this)} getFilteredJobs={this.getFilteredJobs.bind(this)} />
           {(!recentJobs) ?
             "Loading..." :
             <div id="listingsAndFooter">

--- a/lib/components/Searchbar.js
+++ b/lib/components/Searchbar.js
@@ -10,7 +10,7 @@ class SearchBar extends React.Component {
     this.setState({
       activePage: 1
     }, function() {
-      this.getAllRecentJobs();
+      this.props.getAllRecentJobs();
       this.state.inputValue = "";
       document.getElementById('search-bar-input').value = "";
     });


### PR DESCRIPTION
when we inherited this project, the `See All Jobs` button was nonfunctional. after looking into the issue, I found that we were not passing `getAllRecentJobs` into `Searchbar.js`, where the button lives.

after completing that part, I also realized that inside `SearchBar.js`, the function was not being called properly. as a passed-down function, it needed to be called with `this.props.getAllRecentJobs()`.